### PR TITLE
feat: add stable ZRLE decoding support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ doc/api/
 
 # FVM Version Cache
 .fvm/
+.vscode/VNC.code-workspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,4 +50,4 @@
 - Manage Dart SDK via `fvm`
 
 ## 0.9.0
-- Add full support for the ZRLE encoding (client-side decompression plus tests)
+- Add full support for the ZRLE encoding ( thanks @Spokplacenta )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,3 +48,6 @@
 ## 0.8.0
 - Upgrade `binary` to 4.0.0
 - Manage Dart SDK via `fvm`
+
+## 0.9.0
+- Add full support for the ZRLE encoding (client-side decompression plus tests)

--- a/lib/src/client/rectangle_converter.dart
+++ b/lib/src/client/rectangle_converter.dart
@@ -7,11 +7,9 @@ import 'package:dart_rfb/src/protocol/frame_buffer_update_message.dart';
 import 'package:logging/logging.dart';
 
 class RemoteFrameBufferRectangleConverter {
-  RemoteFrameBufferRectangleConverter({
-    required final Logger logger,
-  }) : _logger = logger;
+  RemoteFrameBufferRectangleConverter();
 
-  final Logger _logger;
+  final Logger _logger = Logger('RemoteFrameBufferRectangleConverter');
 
   RemoteFrameBufferClientUpdateRectangle convert({
     required final RemoteFrameBufferFrameBufferUpdateMessageRectangle rectangle,

--- a/lib/src/client/rectangle_converter.dart
+++ b/lib/src/client/rectangle_converter.dart
@@ -1,0 +1,94 @@
+import 'dart:typed_data';
+
+import 'package:dart_rfb/src/client/remote_frame_buffer_client_update.dart';
+import 'package:dart_rfb/src/encodings/zrle_decoder.dart';
+import 'package:dart_rfb/src/protocol/encoding_type.dart';
+import 'package:dart_rfb/src/protocol/frame_buffer_update_message.dart';
+import 'package:logging/logging.dart';
+
+class RemoteFrameBufferRectangleConverter {
+  RemoteFrameBufferRectangleConverter({
+    required final Logger logger,
+  }) : _logger = logger;
+
+  final Logger _logger;
+
+  RemoteFrameBufferClientUpdateRectangle convert({
+    required final RemoteFrameBufferFrameBufferUpdateMessageRectangle rectangle,
+    final ZrleDecoder? zrleDecoder,
+  }) =>
+      rectangle.encodingType.map(
+        copyRect: (final _) => _buildRectangle(
+          rectangle: rectangle,
+          byteData: rectangle.pixelData,
+          encodingType: rectangle.encodingType,
+        ),
+        raw: (final _) => _buildRectangle(
+          rectangle: rectangle,
+          byteData: rectangle.pixelData,
+          encodingType: rectangle.encodingType,
+        ),
+        zrle: (final _) => _handleZrle(
+          rectangle: rectangle,
+          decoder: zrleDecoder,
+        ),
+        unsupported: (final _) => _buildRectangle(
+          rectangle: rectangle,
+          byteData: rectangle.pixelData,
+          encodingType: rectangle.encodingType,
+        ),
+      );
+
+  RemoteFrameBufferClientUpdateRectangle _handleZrle({
+    required final RemoteFrameBufferFrameBufferUpdateMessageRectangle rectangle,
+    required final ZrleDecoder? decoder,
+  }) {
+    if (decoder == null) {
+      _logger.warning(
+        'Received ZRLE rectangle but decoder is not initialised',
+      );
+      return _buildRectangle(
+        rectangle: rectangle,
+        byteData: rectangle.pixelData,
+        encodingType: rectangle.encodingType,
+      );
+    }
+    try {
+      final ByteData decoded = decoder.decode(
+        zrleData: rectangle.pixelData,
+        width: rectangle.width,
+        height: rectangle.height,
+      );
+      return _buildRectangle(
+        rectangle: rectangle,
+        byteData: decoded,
+        encodingType: const RemoteFrameBufferEncodingType.raw(),
+      );
+    } catch (error, stackTrace) {
+      _logger.warning(
+        'Failed to decode ZRLE rectangle: $error',
+      );
+      _logger.fine(stackTrace);
+      return _buildRectangle(
+        rectangle: rectangle,
+        byteData: rectangle.pixelData,
+        encodingType: rectangle.encodingType,
+      );
+    }
+  }
+
+  RemoteFrameBufferClientUpdateRectangle _buildRectangle({
+    required final RemoteFrameBufferFrameBufferUpdateMessageRectangle rectangle,
+    required final ByteData byteData,
+    required final RemoteFrameBufferEncodingType encodingType,
+  }) =>
+      RemoteFrameBufferClientUpdateRectangle(
+        byteData: byteData,
+        encodingType: encodingType,
+        height: rectangle.height,
+        width: rectangle.width,
+        x: rectangle.x,
+        y: rectangle.y,
+      );
+}
+

--- a/lib/src/client/remote_frame_buffer_client.dart
+++ b/lib/src/client/remote_frame_buffer_client.dart
@@ -218,10 +218,7 @@ class RemoteFrameBufferClient {
                   ) =>
                       _rectangleConverter.convert(
                     rectangle: rectangle,
-                    zrleDecoder: _zrleDecoder.match(
-                      () => null,
-                      (final ZrleDecoder decoder) => decoder,
-                    ),
+                    zrleDecoder: _zrleDecoder,
                   ),
                 ).toList();
             _updateStreamController.add(

--- a/lib/src/client/remote_frame_buffer_client.dart
+++ b/lib/src/client/remote_frame_buffer_client.dart
@@ -210,9 +210,8 @@ class RemoteFrameBufferClient {
           bell: () {},
           frameBufferUpdate:
               (final RemoteFrameBufferFrameBufferUpdateMessage message) {
-            _updateStreamController.add(
-              RemoteFrameBufferClientUpdate(
-                rectangles: message.rectangles.map(
+            final List<RemoteFrameBufferClientUpdateRectangle> convertedRectangles =
+                message.rectangles.map(
                   (
                     final RemoteFrameBufferFrameBufferUpdateMessageRectangle
                         rectangle,
@@ -224,7 +223,10 @@ class RemoteFrameBufferClient {
                       (final ZrleDecoder decoder) => decoder,
                     ),
                   ),
-                ),
+                ).toList();
+            _updateStreamController.add(
+              RemoteFrameBufferClientUpdate(
+                rectangles: convertedRectangles,
               ),
             );
           },

--- a/lib/src/client/remote_frame_buffer_client.dart
+++ b/lib/src/client/remote_frame_buffer_client.dart
@@ -58,7 +58,7 @@ class RemoteFrameBufferClient {
   Option<ZrleDecoder> _zrleDecoder = none();
 
   final RemoteFrameBufferRectangleConverter _rectangleConverter =
-      RemoteFrameBufferRectangleConverter(logger: logger);
+      RemoteFrameBufferRectangleConverter();
 
   final StreamController<String> _serverClipBoardStreamController =
       StreamController<String>();

--- a/lib/src/client/remote_frame_buffer_client.dart
+++ b/lib/src/client/remote_frame_buffer_client.dart
@@ -195,7 +195,16 @@ class RemoteFrameBufferClient {
             error,
       ).andThen(_performHandshake).run())
           .match(
-        (final Object error) => throw Exception(error),
+        (final Object error) {
+          // Conserver [SocketException] / [Error] pour l’UI ; sinon envelopper.
+          if (error is Error) {
+            throw error;
+          }
+          if (error is Exception) {
+            throw error;
+          }
+          throw Exception(error);
+        },
         (final _) {},
       );
 

--- a/lib/src/client/remote_frame_buffer_client_read_message.freezed.dart
+++ b/lib/src/client/remote_frame_buffer_client_read_message.freezed.dart
@@ -12,7 +12,7 @@ part of 'remote_frame_buffer_client_read_message.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$RemoteFrameBufferClientReadMessage {
@@ -112,6 +112,9 @@ class _$RemoteFrameBufferClientReadMessageCopyWithImpl<$Res,
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
+
+  /// Create a copy of RemoteFrameBufferClientReadMessage
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -131,6 +134,9 @@ class __$$RemoteFrameBufferClientReadMessageBellImplCopyWithImpl<$Res>
       _$RemoteFrameBufferClientReadMessageBellImpl _value,
       $Res Function(_$RemoteFrameBufferClientReadMessageBellImpl) _then)
       : super(_value, _then);
+
+  /// Create a copy of RemoteFrameBufferClientReadMessage
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -145,7 +151,7 @@ class _$RemoteFrameBufferClientReadMessageBellImpl
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$RemoteFrameBufferClientReadMessageBellImpl);
@@ -290,6 +296,8 @@ class __$$RemoteFrameBufferClientReadMessageFrameBufferUpdateImplCopyWithImpl<
           _then)
       : super(_value, _then);
 
+  /// Create a copy of RemoteFrameBufferClientReadMessage
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -303,6 +311,8 @@ class __$$RemoteFrameBufferClientReadMessageFrameBufferUpdateImplCopyWithImpl<
     ));
   }
 
+  /// Create a copy of RemoteFrameBufferClientReadMessage
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $RemoteFrameBufferFrameBufferUpdateMessageCopyWith<$Res> get message {
@@ -329,7 +339,7 @@ class _$RemoteFrameBufferClientReadMessageFrameBufferUpdateImpl
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other
@@ -340,7 +350,9 @@ class _$RemoteFrameBufferClientReadMessageFrameBufferUpdateImpl
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RemoteFrameBufferClientReadMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$RemoteFrameBufferClientReadMessageFrameBufferUpdateImplCopyWith<
@@ -457,7 +469,10 @@ abstract class _RemoteFrameBufferClientReadMessageFrameBufferUpdate
       _$RemoteFrameBufferClientReadMessageFrameBufferUpdateImpl;
 
   RemoteFrameBufferFrameBufferUpdateMessage get message;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of RemoteFrameBufferClientReadMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$RemoteFrameBufferClientReadMessageFrameBufferUpdateImplCopyWith<
           _$RemoteFrameBufferClientReadMessageFrameBufferUpdateImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -494,6 +509,8 @@ class __$$RemoteFrameBufferClientReadMessageServerCutTextMessageImplCopyWithImpl
           _then)
       : super(_value, _then);
 
+  /// Create a copy of RemoteFrameBufferClientReadMessage
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -507,6 +524,8 @@ class __$$RemoteFrameBufferClientReadMessageServerCutTextMessageImplCopyWithImpl
     ));
   }
 
+  /// Create a copy of RemoteFrameBufferClientReadMessage
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $RemoteFrameBufferServerCutTextMessageCopyWith<$Res> get message {
@@ -533,7 +552,7 @@ class _$RemoteFrameBufferClientReadMessageServerCutTextMessageImpl
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other
@@ -544,7 +563,9 @@ class _$RemoteFrameBufferClientReadMessageServerCutTextMessageImpl
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RemoteFrameBufferClientReadMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$RemoteFrameBufferClientReadMessageServerCutTextMessageImplCopyWith<
@@ -661,7 +682,10 @@ abstract class _RemoteFrameBufferClientReadMessageServerCutTextMessage
       _$RemoteFrameBufferClientReadMessageServerCutTextMessageImpl;
 
   RemoteFrameBufferServerCutTextMessage get message;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of RemoteFrameBufferClientReadMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$RemoteFrameBufferClientReadMessageServerCutTextMessageImplCopyWith<
           _$RemoteFrameBufferClientReadMessageServerCutTextMessageImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -692,6 +716,9 @@ class __$$RemoteFrameBufferClientReadMessageSetColorMapEntriesImplCopyWithImpl<
       $Res Function(_$RemoteFrameBufferClientReadMessageSetColorMapEntriesImpl)
           _then)
       : super(_value, _then);
+
+  /// Create a copy of RemoteFrameBufferClientReadMessage
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -706,7 +733,7 @@ class _$RemoteFrameBufferClientReadMessageSetColorMapEntriesImpl
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other

--- a/lib/src/client/remote_frame_buffer_client_update.freezed.dart
+++ b/lib/src/client/remote_frame_buffer_client_update.freezed.dart
@@ -12,14 +12,16 @@ part of 'remote_frame_buffer_client_update.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$RemoteFrameBufferClientFrameBufferConfig {
   int get height => throw _privateConstructorUsedError;
   int get width => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RemoteFrameBufferClientFrameBufferConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $RemoteFrameBufferClientFrameBufferConfigCopyWith<
           RemoteFrameBufferClientFrameBufferConfig>
       get copyWith => throw _privateConstructorUsedError;
@@ -48,6 +50,8 @@ class _$RemoteFrameBufferClientFrameBufferConfigCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of RemoteFrameBufferClientFrameBufferConfig
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -89,6 +93,8 @@ class __$$RemoteFrameBufferClientFrameBufferConfigImplCopyWithImpl<$Res>
       $Res Function(_$RemoteFrameBufferClientFrameBufferConfigImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of RemoteFrameBufferClientFrameBufferConfig
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -126,7 +132,7 @@ class _$RemoteFrameBufferClientFrameBufferConfigImpl
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$RemoteFrameBufferClientFrameBufferConfigImpl &&
@@ -137,7 +143,9 @@ class _$RemoteFrameBufferClientFrameBufferConfigImpl
   @override
   int get hashCode => Object.hash(runtimeType, height, width);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RemoteFrameBufferClientFrameBufferConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$RemoteFrameBufferClientFrameBufferConfigImplCopyWith<
@@ -157,8 +165,11 @@ abstract class _RemoteFrameBufferClientFrameBufferConfig
   int get height;
   @override
   int get width;
+
+  /// Create a copy of RemoteFrameBufferClientFrameBufferConfig
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$RemoteFrameBufferClientFrameBufferConfigImplCopyWith<
           _$RemoteFrameBufferClientFrameBufferConfigImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -170,7 +181,9 @@ mixin _$RemoteFrameBufferClientUpdate {
   Iterable<RemoteFrameBufferClientUpdateRectangle> get rectangles =>
       throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RemoteFrameBufferClientUpdate
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $RemoteFrameBufferClientUpdateCopyWith<RemoteFrameBufferClientUpdate>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -197,6 +210,8 @@ class _$RemoteFrameBufferClientUpdateCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of RemoteFrameBufferClientUpdate
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -233,6 +248,8 @@ class __$$RemoteFrameBufferClientUpdateImplCopyWithImpl<$Res>
       $Res Function(_$RemoteFrameBufferClientUpdateImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of RemoteFrameBufferClientUpdate
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -263,7 +280,7 @@ class _$RemoteFrameBufferClientUpdateImpl
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$RemoteFrameBufferClientUpdateImpl &&
@@ -275,7 +292,9 @@ class _$RemoteFrameBufferClientUpdateImpl
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(rectangles));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RemoteFrameBufferClientUpdate
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$RemoteFrameBufferClientUpdateImplCopyWith<
@@ -290,12 +309,14 @@ abstract class _RemoteFrameBufferClientUpdate
       {required final Iterable<RemoteFrameBufferClientUpdateRectangle>
           rectangles}) = _$RemoteFrameBufferClientUpdateImpl;
 
-  @override
-
   /// The list of [RemoteFrameBufferClientUpdateRectangle]s that make this update.
-  Iterable<RemoteFrameBufferClientUpdateRectangle> get rectangles;
   @override
-  @JsonKey(ignore: true)
+  Iterable<RemoteFrameBufferClientUpdateRectangle> get rectangles;
+
+  /// Create a copy of RemoteFrameBufferClientUpdate
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$RemoteFrameBufferClientUpdateImplCopyWith<
           _$RemoteFrameBufferClientUpdateImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -322,7 +343,9 @@ mixin _$RemoteFrameBufferClientUpdateRectangle {
   /// The starting y offset of this rectangle.
   int get y => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RemoteFrameBufferClientUpdateRectangle
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $RemoteFrameBufferClientUpdateRectangleCopyWith<
           RemoteFrameBufferClientUpdateRectangle>
       get copyWith => throw _privateConstructorUsedError;
@@ -358,6 +381,8 @@ class _$RemoteFrameBufferClientUpdateRectangleCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of RemoteFrameBufferClientUpdateRectangle
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -396,6 +421,8 @@ class _$RemoteFrameBufferClientUpdateRectangleCopyWithImpl<$Res,
     ) as $Val);
   }
 
+  /// Create a copy of RemoteFrameBufferClientUpdateRectangle
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $RemoteFrameBufferEncodingTypeCopyWith<$Res> get encodingType {
@@ -437,6 +464,8 @@ class __$$RemoteFrameBufferClientUpdateRectangleImplCopyWithImpl<$Res>
       $Res Function(_$RemoteFrameBufferClientUpdateRectangleImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of RemoteFrameBufferClientUpdateRectangle
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -518,7 +547,7 @@ class _$RemoteFrameBufferClientUpdateRectangleImpl
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$RemoteFrameBufferClientUpdateRectangleImpl &&
@@ -536,7 +565,9 @@ class _$RemoteFrameBufferClientUpdateRectangleImpl
   int get hashCode =>
       Object.hash(runtimeType, byteData, encodingType, height, width, x, y);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RemoteFrameBufferClientUpdateRectangle
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$RemoteFrameBufferClientUpdateRectangleImplCopyWith<
@@ -556,32 +587,34 @@ abstract class _RemoteFrameBufferClientUpdateRectangle
       required final int x,
       required final int y}) = _$RemoteFrameBufferClientUpdateRectangleImpl;
 
-  @override
-
   /// The [ByteData] that holds the pixel data of this rectangle.
-  ByteData get byteData;
   @override
+  ByteData get byteData;
 
   /// The encoding used to interpret the bytes in [byteData].
-  RemoteFrameBufferEncodingType get encodingType;
   @override
+  RemoteFrameBufferEncodingType get encodingType;
 
   /// The height in pixels.
-  int get height;
   @override
+  int get height;
 
   /// The width in pixels.
-  int get width;
   @override
+  int get width;
 
   /// The starting x offset of this rectangle.
-  int get x;
   @override
+  int get x;
 
   /// The starting y offset of this rectangle.
-  int get y;
   @override
-  @JsonKey(ignore: true)
+  int get y;
+
+  /// Create a copy of RemoteFrameBufferClientUpdateRectangle
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$RemoteFrameBufferClientUpdateRectangleImplCopyWith<
           _$RemoteFrameBufferClientUpdateRectangleImpl>
       get copyWith => throw _privateConstructorUsedError;

--- a/lib/src/encodings/zrle_decoder.dart
+++ b/lib/src/encodings/zrle_decoder.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';

--- a/lib/src/encodings/zrle_decoder.dart
+++ b/lib/src/encodings/zrle_decoder.dart
@@ -1,0 +1,476 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:dart_rfb/src/protocol/pixel_format.dart';
+
+/// Decoder for ZRLE rectangles (see RFC 6143 §7.7.6.9).
+///
+/// The decoder currently assumes little-endian pixel formats, which matches the
+/// `bgra8888` format negotiated by the client.
+class ZrleDecoder {
+  ZrleDecoder({
+    required final RemoteFrameBufferPixelFormat pixelFormat,
+  })  : _pixelFormat = pixelFormat,
+        _bytesPerPixel = (pixelFormat.bitsPerPixel / 8).ceil(),
+        _cpixelSize = ((pixelFormat.depth + 7) ~/ 8);
+
+  final RemoteFrameBufferPixelFormat _pixelFormat;
+  final int _bytesPerPixel;
+  final int _cpixelSize;
+
+  /// Decode [zrleData] (length + compressed payload) into raw pixel bytes.
+  ByteData decode({
+    required final ByteData zrleData,
+    required final int width,
+    required final int height,
+  }) {
+    if (zrleData.lengthInBytes < 4) {
+      throw const FormatException('ZRLE rectangle is missing length bytes');
+    }
+    final int declaredLength = zrleData.getUint32(0);
+    if (zrleData.lengthInBytes - 4 < declaredLength) {
+      throw const FormatException('ZRLE payload shorter than declared length');
+    }
+    final Uint8List compressedPayload = zrleData.buffer.asUint8List(
+      zrleData.offsetInBytes + 4,
+      declaredLength,
+    );
+    if (compressedPayload.isEmpty) {
+      return ByteData(width * height * _bytesPerPixel);
+    }
+    final Uint8List decompressed =
+        Uint8List.fromList(ZLibCodec().decode(compressedPayload));
+    final Uint8List frameBuffer = Uint8List(width * height * _bytesPerPixel);
+
+    int offset = 0;
+    for (int tileY = 0; tileY < height; tileY += 64) {
+      final int tileHeight = min(64, height - tileY);
+      for (int tileX = 0; tileX < width; tileX += 64) {
+        final int tileWidth = min(64, width - tileX);
+        offset = _decodeTile(
+          data: decompressed,
+          offset: offset,
+          tileX: tileX,
+          tileY: tileY,
+          tileWidth: tileWidth,
+          tileHeight: tileHeight,
+          frameBuffer: frameBuffer,
+          frameWidth: width,
+        );
+      }
+    }
+    if (offset > decompressed.length) {
+      throw const FormatException('ZRLE payload shorter than expected');
+    }
+    return ByteData.sublistView(frameBuffer);
+  }
+
+  int _decodeTile({
+    required final Uint8List data,
+    required final int offset,
+    required final int tileX,
+    required final int tileY,
+    required final int tileWidth,
+    required final int tileHeight,
+    required final Uint8List frameBuffer,
+    required final int frameWidth,
+  }) {
+    if (offset >= data.length) {
+      throw const FormatException('Unexpected end of ZRLE payload (tile type)');
+    }
+    final int type = data[offset];
+    final int tileOffset = offset + 1;
+    if (type == 0) {
+      return _decodeRawTile(
+        data: data,
+        offset: tileOffset,
+        tileX: tileX,
+        tileY: tileY,
+        tileWidth: tileWidth,
+        tileHeight: tileHeight,
+        frameBuffer: frameBuffer,
+        frameWidth: frameWidth,
+      );
+    } else if (type == 1) {
+      return _decodeSolidTile(
+        data: data,
+        offset: tileOffset,
+        tileX: tileX,
+        tileY: tileY,
+        tileWidth: tileWidth,
+        tileHeight: tileHeight,
+        frameBuffer: frameBuffer,
+        frameWidth: frameWidth,
+      );
+    } else if (type >= 2 && type <= 127) {
+      return _decodePackedPaletteTile(
+        data: data,
+        offset: tileOffset,
+        paletteSize: type,
+        tileX: tileX,
+        tileY: tileY,
+        tileWidth: tileWidth,
+        tileHeight: tileHeight,
+        frameBuffer: frameBuffer,
+        frameWidth: frameWidth,
+      );
+    } else if (type == 128) {
+      return _decodePlainRleTile(
+        data: data,
+        offset: tileOffset,
+        tileX: tileX,
+        tileY: tileY,
+        tileWidth: tileWidth,
+        tileHeight: tileHeight,
+        frameBuffer: frameBuffer,
+        frameWidth: frameWidth,
+      );
+    } else if (type >= 130 && type <= 255) {
+      return _decodePaletteRleTile(
+        data: data,
+        offset: tileOffset,
+        paletteSize: type - 128,
+        tileX: tileX,
+        tileY: tileY,
+        tileWidth: tileWidth,
+        tileHeight: tileHeight,
+        frameBuffer: frameBuffer,
+        frameWidth: frameWidth,
+      );
+    }
+    throw FormatException('Unsupported ZRLE tile type: $type');
+  }
+
+  int _decodeRawTile({
+    required final Uint8List data,
+    required final int offset,
+    required final int tileX,
+    required final int tileY,
+    required final int tileWidth,
+    required final int tileHeight,
+    required final Uint8List frameBuffer,
+    required final int frameWidth,
+  }) {
+    final int pixels = tileWidth * tileHeight;
+    final int bytesNeeded = pixels * _cpixelSize;
+    if (offset + bytesNeeded > data.length) {
+      throw const FormatException('Raw tile truncated');
+    }
+    int currentOffset = offset;
+    for (int row = 0; row < tileHeight; row++) {
+      for (int col = 0; col < tileWidth; col++) {
+        final int dstOffset = ((tileY + row) * frameWidth + tileX + col) *
+            _bytesPerPixel;
+        _writeCpixelToFrame(
+          cpixelBytes: data,
+          cpixelOffset: currentOffset,
+          destination: frameBuffer,
+          destinationOffset: dstOffset,
+        );
+        currentOffset += _cpixelSize;
+      }
+    }
+    return currentOffset;
+  }
+
+  int _decodeSolidTile({
+    required final Uint8List data,
+    required final int offset,
+    required final int tileX,
+    required final int tileY,
+    required final int tileWidth,
+    required final int tileHeight,
+    required final Uint8List frameBuffer,
+    required final int frameWidth,
+  }) {
+    if (offset + _cpixelSize > data.length) {
+      throw const FormatException('Solid tile missing color');
+    }
+    final Uint8List color = Uint8List(_bytesPerPixel);
+    _writeCpixelToFrame(
+      cpixelBytes: data,
+      cpixelOffset: offset,
+      destination: color,
+      destinationOffset: 0,
+    );
+    for (int row = 0; row < tileHeight; row++) {
+      for (int col = 0; col < tileWidth; col++) {
+        final int dstOffset = ((tileY + row) * frameWidth + tileX + col) *
+            _bytesPerPixel;
+        frameBuffer.setRange(
+          dstOffset,
+          dstOffset + _bytesPerPixel,
+          color,
+        );
+      }
+    }
+    return offset + _cpixelSize;
+  }
+
+  int _decodePackedPaletteTile({
+    required final Uint8List data,
+    required final int offset,
+    required final int paletteSize,
+    required final int tileX,
+    required final int tileY,
+    required final int tileWidth,
+    required final int tileHeight,
+    required final Uint8List frameBuffer,
+    required final int frameWidth,
+  }) {
+    final int paletteBytes = paletteSize * _cpixelSize;
+    if (offset + paletteBytes > data.length) {
+      throw const FormatException('Packed palette tile missing palette data');
+    }
+    final List<Uint8List> palette = List<Uint8List>.generate(
+      paletteSize,
+      (final int index) {
+        final Uint8List color = Uint8List(_bytesPerPixel);
+        _writeCpixelToFrame(
+          cpixelBytes: data,
+          cpixelOffset: offset + index * _cpixelSize,
+          destination: color,
+          destinationOffset: 0,
+        );
+        return color;
+      },
+    );
+    final int dataOffset = offset + paletteBytes;
+    final int bitsPerPixel = paletteSize <= 2
+        ? 1
+        : paletteSize <= 4
+            ? 2
+            : paletteSize <= 16
+                ? 4
+                : 8;
+    final int pixelsPerByte = 8 ~/ bitsPerPixel;
+    final int bytesPerRow =
+        ((tileWidth + pixelsPerByte - 1) ~/ pixelsPerByte).toInt();
+    final int packedBytes = bytesPerRow * tileHeight;
+    if (dataOffset + packedBytes > data.length) {
+      throw const FormatException('Packed palette tile truncated');
+    }
+    int currentOffset = dataOffset;
+    for (int row = 0; row < tileHeight; row++) {
+      int shift = 8 - bitsPerPixel;
+      for (int col = 0; col < tileWidth; col++) {
+        final int byteValue = data[currentOffset];
+        final int paletteIndex =
+            (byteValue >> shift) & ((1 << bitsPerPixel) - 1);
+        if (paletteIndex >= palette.length) {
+          throw const FormatException('Packed palette index out of range');
+        }
+        final int dstOffset =
+            ((tileY + row) * frameWidth + tileX + col) * _bytesPerPixel;
+        frameBuffer.setRange(
+          dstOffset,
+          dstOffset + _bytesPerPixel,
+          palette[paletteIndex],
+        );
+        shift -= bitsPerPixel;
+        if (shift < 0) {
+          shift = 8 - bitsPerPixel;
+          currentOffset++;
+          if (currentOffset >= dataOffset + packedBytes && row != tileHeight) {
+            throw const FormatException('Packed palette exhausted early');
+          }
+        }
+      }
+      if (shift < 8 - bitsPerPixel) {
+        currentOffset++;
+      }
+    }
+    return currentOffset;
+  }
+
+  int _decodePlainRleTile({
+    required final Uint8List data,
+    required final int offset,
+    required final int tileX,
+    required final int tileY,
+    required final int tileWidth,
+    required final int tileHeight,
+    required final Uint8List frameBuffer,
+    required final int frameWidth,
+  }) {
+    int currentOffset = offset;
+    int row = 0;
+    int col = 0;
+    final Uint8List colorBuffer = Uint8List(_bytesPerPixel);
+    while (row < tileHeight) {
+      if (currentOffset + _cpixelSize > data.length) {
+        throw const FormatException('Plain RLE tile truncated (color)');
+      }
+      _writeCpixelToFrame(
+        cpixelBytes: data,
+        cpixelOffset: currentOffset,
+        destination: colorBuffer,
+        destinationOffset: 0,
+      );
+      currentOffset += _cpixelSize;
+      final _RunLengthResult run = _readRunLength(
+        data: data,
+        offset: currentOffset,
+        description: 'Plain RLE length',
+      );
+      currentOffset += run.bytesConsumed;
+      int remaining = run.length;
+      while (remaining > 0) {
+        if (row >= tileHeight) {
+          throw const FormatException('Plain RLE overruns tile height');
+        }
+        final int dstOffset =
+            ((tileY + row) * frameWidth + tileX + col) * _bytesPerPixel;
+        frameBuffer.setRange(
+          dstOffset,
+          dstOffset + _bytesPerPixel,
+          colorBuffer,
+        );
+        col++;
+        if (col >= tileWidth) {
+          col = 0;
+          row++;
+        }
+        remaining--;
+      }
+    }
+    return currentOffset;
+  }
+
+  int _decodePaletteRleTile({
+    required final Uint8List data,
+    required final int offset,
+    required final int paletteSize,
+    required final int tileX,
+    required final int tileY,
+    required final int tileWidth,
+    required final int tileHeight,
+    required final Uint8List frameBuffer,
+    required final int frameWidth,
+  }) {
+    final int paletteBytes = paletteSize * _cpixelSize;
+    if (offset + paletteBytes > data.length) {
+      throw const FormatException('Palette RLE tile missing palette data');
+    }
+    final List<Uint8List> palette = List<Uint8List>.generate(
+      paletteSize,
+      (final int index) {
+        final Uint8List color = Uint8List(_bytesPerPixel);
+        _writeCpixelToFrame(
+          cpixelBytes: data,
+          cpixelOffset: offset + index * _cpixelSize,
+          destination: color,
+          destinationOffset: 0,
+        );
+        return color;
+      },
+    );
+    int currentOffset = offset + paletteBytes;
+    int row = 0;
+    int col = 0;
+    while (row < tileHeight) {
+      if (currentOffset >= data.length) {
+        throw const FormatException('Palette RLE tile truncated (entry)');
+      }
+      final int entry = data[currentOffset++];
+      final bool isRun = (entry & 0x80) != 0;
+      final int paletteIndex = entry & 0x7F;
+      if (paletteIndex >= palette.length) {
+        throw const FormatException('Palette RLE index out of range');
+      }
+      int runLength = 1;
+      if (isRun) {
+        final _RunLengthResult run = _readRunLength(
+          data: data,
+          offset: currentOffset,
+          description: 'Palette RLE length',
+        );
+        runLength = run.length;
+        currentOffset += run.bytesConsumed;
+      }
+      int remaining = runLength;
+      while (remaining > 0) {
+        if (row >= tileHeight) {
+          throw const FormatException('Palette RLE overruns tile height');
+        }
+        final int dstOffset =
+            ((tileY + row) * frameWidth + tileX + col) * _bytesPerPixel;
+        frameBuffer.setRange(
+          dstOffset,
+          dstOffset + _bytesPerPixel,
+          palette[paletteIndex],
+        );
+        col++;
+        if (col >= tileWidth) {
+          col = 0;
+          row++;
+        }
+        remaining--;
+      }
+    }
+    return currentOffset;
+  }
+
+  _RunLengthResult _readRunLength({
+    required final Uint8List data,
+    required final int offset,
+    required final String description,
+  }) {
+    if (offset >= data.length) {
+      throw FormatException('$description truncated');
+    }
+    int length = 1;
+    int consumed = 0;
+    int currentOffset = offset;
+    while (currentOffset < data.length && data[currentOffset] == 0xFF) {
+      length += 255;
+      currentOffset++;
+      consumed++;
+      if (currentOffset >= data.length) {
+        throw FormatException('$description truncated');
+      }
+    }
+    length += data[currentOffset];
+    consumed++;
+    return _RunLengthResult(length: length, bytesConsumed: consumed);
+  }
+
+  void _writeCpixelToFrame({
+    required final Uint8List cpixelBytes,
+    required final int cpixelOffset,
+    required final Uint8List destination,
+    required final int destinationOffset,
+  }) {
+    if (_pixelFormat.bigEndian) {
+      final int padding = _bytesPerPixel - _cpixelSize;
+      for (int i = 0; i < padding; i++) {
+        destination[destinationOffset + i] = 0;
+      }
+      for (int i = 0; i < _cpixelSize; i++) {
+        destination[destinationOffset + padding + i] =
+            cpixelBytes[cpixelOffset + i];
+      }
+      return;
+    }
+    for (int i = 0; i < _cpixelSize; i++) {
+      destination[destinationOffset + i] =
+          cpixelBytes[cpixelOffset + i];
+    }
+    for (int i = _cpixelSize; i < _bytesPerPixel; i++) {
+      destination[destinationOffset + i] = 0;
+    }
+  }
+}
+
+class _RunLengthResult {
+  const _RunLengthResult({
+    required this.length,
+    required this.bytesConsumed,
+  });
+
+  final int length;
+  final int bytesConsumed;
+}
+

--- a/lib/src/encodings/zrle_decoder.dart
+++ b/lib/src/encodings/zrle_decoder.dart
@@ -482,7 +482,9 @@ class ZrleDecoder {
       destination[destinationOffset + i] =
           cpixelBytes[cpixelOffset + i];
     }
-    // Set alpha channel to 255 (fully opaque) for BGRA format
+    // Set alpha channel to 255 (fully opaque) for BGRA format.
+    // This relies on _cpixelSize == 3 for 24-bit depth (RGB) and _bytesPerPixel == 4 (BGRA8888),
+    // so this correctly sets byte index 3 (alpha channel) to 0xFF.
     for (int i = _cpixelSize; i < _bytesPerPixel; i++) {
       destination[destinationOffset + i] = 0xFF;
     }

--- a/lib/src/encodings/zrle_decoder.dart
+++ b/lib/src/encodings/zrle_decoder.dart
@@ -269,8 +269,7 @@ class ZrleDecoder {
                 ? 4
                 : 8;
     final int pixelsPerByte = 8 ~/ bitsPerPixel;
-    final int bytesPerRow =
-        ((tileWidth + pixelsPerByte - 1) ~/ pixelsPerByte).toInt();
+    final int bytesPerRow = (tileWidth + pixelsPerByte - 1) ~/ pixelsPerByte;
     final int packedBytes = bytesPerRow * tileHeight;
     if (dataOffset + packedBytes > data.length) {
       throw const FormatException('Packed palette tile truncated');
@@ -278,7 +277,7 @@ class ZrleDecoder {
     int currentOffset = dataOffset;
     for (int row = 0; row < tileHeight; row++) {
       int shift = 8 - bitsPerPixel;
-      int rowStartOffset = currentOffset;
+      final int rowStartOffset = currentOffset;
       for (int col = 0; col < tileWidth; col++) {
         if (currentOffset >= data.length) {
           throw const FormatException('Packed palette tile data exhausted');
@@ -500,4 +499,3 @@ class _RunLengthResult {
   final int length;
   final int bytesConsumed;
 }
-

--- a/lib/src/protocol/encoding_type.dart
+++ b/lib/src/protocol/encoding_type.dart
@@ -13,6 +13,8 @@ class RemoteFrameBufferEncodingType with _$RemoteFrameBufferEncodingType {
       RemoteFrameBufferEncodingTypeCopyRect;
   const factory RemoteFrameBufferEncodingType.raw() =
       RemoteFrameBufferEncodingTypeRaw;
+  const factory RemoteFrameBufferEncodingType.zrle() =
+      RemoteFrameBufferEncodingTypeZrle;
   const factory RemoteFrameBufferEncodingType.unsupported({
     required final ByteData bytes,
   }) = RemoteFrameBufferEncodingTypeUnsupported;
@@ -26,6 +28,8 @@ class RemoteFrameBufferEncodingType with _$RemoteFrameBufferEncodingType {
         return const RemoteFrameBufferEncodingType.raw();
       case 1:
         return const RemoteFrameBufferEncodingType.copyRect();
+      case 16:
+        return const RemoteFrameBufferEncodingType.zrle();
       default:
         return RemoteFrameBufferEncodingType.unsupported(bytes: bytes);
     }
@@ -38,6 +42,7 @@ class RemoteFrameBufferEncodingType with _$RemoteFrameBufferEncodingType {
       map(
         copyRect: (final _) => 1,
         raw: (final _) => 0,
+        zrle: (final _) => 16,
         unsupported: (final _) => -1,
       ),
     );

--- a/lib/src/protocol/encoding_type.dart
+++ b/lib/src/protocol/encoding_type.dart
@@ -35,7 +35,7 @@ class RemoteFrameBufferEncodingType with _$RemoteFrameBufferEncodingType {
     }
   }
 
-  /// Generate byte representation of thie encoding type.
+  /// Generate byte representation of this encoding type.
   ByteData toBytes() => ByteData(4)
     ..setInt32(
       0,

--- a/lib/src/protocol/encoding_type.freezed.dart
+++ b/lib/src/protocol/encoding_type.freezed.dart
@@ -12,7 +12,7 @@ part of 'encoding_type.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$RemoteFrameBufferEncodingType {
@@ -20,6 +20,7 @@ mixin _$RemoteFrameBufferEncodingType {
   TResult when<TResult extends Object?>({
     required TResult Function() copyRect,
     required TResult Function() raw,
+    required TResult Function() zrle,
     required TResult Function(ByteData bytes) unsupported,
   }) =>
       throw _privateConstructorUsedError;
@@ -27,6 +28,7 @@ mixin _$RemoteFrameBufferEncodingType {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? copyRect,
     TResult? Function()? raw,
+    TResult? Function()? zrle,
     TResult? Function(ByteData bytes)? unsupported,
   }) =>
       throw _privateConstructorUsedError;
@@ -34,6 +36,7 @@ mixin _$RemoteFrameBufferEncodingType {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? copyRect,
     TResult Function()? raw,
+    TResult Function()? zrle,
     TResult Function(ByteData bytes)? unsupported,
     required TResult orElse(),
   }) =>
@@ -43,6 +46,7 @@ mixin _$RemoteFrameBufferEncodingType {
     required TResult Function(RemoteFrameBufferEncodingTypeCopyRect value)
         copyRect,
     required TResult Function(RemoteFrameBufferEncodingTypeRaw value) raw,
+    required TResult Function(RemoteFrameBufferEncodingTypeZrle value) zrle,
     required TResult Function(RemoteFrameBufferEncodingTypeUnsupported value)
         unsupported,
   }) =>
@@ -51,6 +55,7 @@ mixin _$RemoteFrameBufferEncodingType {
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(RemoteFrameBufferEncodingTypeCopyRect value)? copyRect,
     TResult? Function(RemoteFrameBufferEncodingTypeRaw value)? raw,
+    TResult? Function(RemoteFrameBufferEncodingTypeZrle value)? zrle,
     TResult? Function(RemoteFrameBufferEncodingTypeUnsupported value)?
         unsupported,
   }) =>
@@ -59,6 +64,7 @@ mixin _$RemoteFrameBufferEncodingType {
   TResult maybeMap<TResult extends Object?>({
     TResult Function(RemoteFrameBufferEncodingTypeCopyRect value)? copyRect,
     TResult Function(RemoteFrameBufferEncodingTypeRaw value)? raw,
+    TResult Function(RemoteFrameBufferEncodingTypeZrle value)? zrle,
     TResult Function(RemoteFrameBufferEncodingTypeUnsupported value)?
         unsupported,
     required TResult orElse(),
@@ -85,6 +91,9 @@ class _$RemoteFrameBufferEncodingTypeCopyWithImpl<$Res,
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
+
+  /// Create a copy of RemoteFrameBufferEncodingType
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -104,6 +113,9 @@ class __$$RemoteFrameBufferEncodingTypeCopyRectImplCopyWithImpl<$Res>
       _$RemoteFrameBufferEncodingTypeCopyRectImpl _value,
       $Res Function(_$RemoteFrameBufferEncodingTypeCopyRectImpl) _then)
       : super(_value, _then);
+
+  /// Create a copy of RemoteFrameBufferEncodingType
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -118,7 +130,7 @@ class _$RemoteFrameBufferEncodingTypeCopyRectImpl
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$RemoteFrameBufferEncodingTypeCopyRectImpl);
@@ -132,6 +144,7 @@ class _$RemoteFrameBufferEncodingTypeCopyRectImpl
   TResult when<TResult extends Object?>({
     required TResult Function() copyRect,
     required TResult Function() raw,
+    required TResult Function() zrle,
     required TResult Function(ByteData bytes) unsupported,
   }) {
     return copyRect();
@@ -142,6 +155,7 @@ class _$RemoteFrameBufferEncodingTypeCopyRectImpl
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? copyRect,
     TResult? Function()? raw,
+    TResult? Function()? zrle,
     TResult? Function(ByteData bytes)? unsupported,
   }) {
     return copyRect?.call();
@@ -152,6 +166,7 @@ class _$RemoteFrameBufferEncodingTypeCopyRectImpl
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? copyRect,
     TResult Function()? raw,
+    TResult Function()? zrle,
     TResult Function(ByteData bytes)? unsupported,
     required TResult orElse(),
   }) {
@@ -167,6 +182,7 @@ class _$RemoteFrameBufferEncodingTypeCopyRectImpl
     required TResult Function(RemoteFrameBufferEncodingTypeCopyRect value)
         copyRect,
     required TResult Function(RemoteFrameBufferEncodingTypeRaw value) raw,
+    required TResult Function(RemoteFrameBufferEncodingTypeZrle value) zrle,
     required TResult Function(RemoteFrameBufferEncodingTypeUnsupported value)
         unsupported,
   }) {
@@ -178,6 +194,7 @@ class _$RemoteFrameBufferEncodingTypeCopyRectImpl
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(RemoteFrameBufferEncodingTypeCopyRect value)? copyRect,
     TResult? Function(RemoteFrameBufferEncodingTypeRaw value)? raw,
+    TResult? Function(RemoteFrameBufferEncodingTypeZrle value)? zrle,
     TResult? Function(RemoteFrameBufferEncodingTypeUnsupported value)?
         unsupported,
   }) {
@@ -189,6 +206,7 @@ class _$RemoteFrameBufferEncodingTypeCopyRectImpl
   TResult maybeMap<TResult extends Object?>({
     TResult Function(RemoteFrameBufferEncodingTypeCopyRect value)? copyRect,
     TResult Function(RemoteFrameBufferEncodingTypeRaw value)? raw,
+    TResult Function(RemoteFrameBufferEncodingTypeZrle value)? zrle,
     TResult Function(RemoteFrameBufferEncodingTypeUnsupported value)?
         unsupported,
     required TResult orElse(),
@@ -224,6 +242,9 @@ class __$$RemoteFrameBufferEncodingTypeRawImplCopyWithImpl<$Res>
       _$RemoteFrameBufferEncodingTypeRawImpl _value,
       $Res Function(_$RemoteFrameBufferEncodingTypeRawImpl) _then)
       : super(_value, _then);
+
+  /// Create a copy of RemoteFrameBufferEncodingType
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -238,7 +259,7 @@ class _$RemoteFrameBufferEncodingTypeRawImpl
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$RemoteFrameBufferEncodingTypeRawImpl);
@@ -252,6 +273,7 @@ class _$RemoteFrameBufferEncodingTypeRawImpl
   TResult when<TResult extends Object?>({
     required TResult Function() copyRect,
     required TResult Function() raw,
+    required TResult Function() zrle,
     required TResult Function(ByteData bytes) unsupported,
   }) {
     return raw();
@@ -262,6 +284,7 @@ class _$RemoteFrameBufferEncodingTypeRawImpl
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? copyRect,
     TResult? Function()? raw,
+    TResult? Function()? zrle,
     TResult? Function(ByteData bytes)? unsupported,
   }) {
     return raw?.call();
@@ -272,6 +295,7 @@ class _$RemoteFrameBufferEncodingTypeRawImpl
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? copyRect,
     TResult Function()? raw,
+    TResult Function()? zrle,
     TResult Function(ByteData bytes)? unsupported,
     required TResult orElse(),
   }) {
@@ -287,6 +311,7 @@ class _$RemoteFrameBufferEncodingTypeRawImpl
     required TResult Function(RemoteFrameBufferEncodingTypeCopyRect value)
         copyRect,
     required TResult Function(RemoteFrameBufferEncodingTypeRaw value) raw,
+    required TResult Function(RemoteFrameBufferEncodingTypeZrle value) zrle,
     required TResult Function(RemoteFrameBufferEncodingTypeUnsupported value)
         unsupported,
   }) {
@@ -298,6 +323,7 @@ class _$RemoteFrameBufferEncodingTypeRawImpl
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(RemoteFrameBufferEncodingTypeCopyRect value)? copyRect,
     TResult? Function(RemoteFrameBufferEncodingTypeRaw value)? raw,
+    TResult? Function(RemoteFrameBufferEncodingTypeZrle value)? zrle,
     TResult? Function(RemoteFrameBufferEncodingTypeUnsupported value)?
         unsupported,
   }) {
@@ -309,6 +335,7 @@ class _$RemoteFrameBufferEncodingTypeRawImpl
   TResult maybeMap<TResult extends Object?>({
     TResult Function(RemoteFrameBufferEncodingTypeCopyRect value)? copyRect,
     TResult Function(RemoteFrameBufferEncodingTypeRaw value)? raw,
+    TResult Function(RemoteFrameBufferEncodingTypeZrle value)? zrle,
     TResult Function(RemoteFrameBufferEncodingTypeUnsupported value)?
         unsupported,
     required TResult orElse(),
@@ -325,6 +352,135 @@ abstract class RemoteFrameBufferEncodingTypeRaw
   const factory RemoteFrameBufferEncodingTypeRaw() =
       _$RemoteFrameBufferEncodingTypeRawImpl;
   const RemoteFrameBufferEncodingTypeRaw._() : super._();
+}
+
+/// @nodoc
+abstract class _$$RemoteFrameBufferEncodingTypeZrleImplCopyWith<$Res> {
+  factory _$$RemoteFrameBufferEncodingTypeZrleImplCopyWith(
+          _$RemoteFrameBufferEncodingTypeZrleImpl value,
+          $Res Function(_$RemoteFrameBufferEncodingTypeZrleImpl) then) =
+      __$$RemoteFrameBufferEncodingTypeZrleImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$RemoteFrameBufferEncodingTypeZrleImplCopyWithImpl<$Res>
+    extends _$RemoteFrameBufferEncodingTypeCopyWithImpl<$Res,
+        _$RemoteFrameBufferEncodingTypeZrleImpl>
+    implements _$$RemoteFrameBufferEncodingTypeZrleImplCopyWith<$Res> {
+  __$$RemoteFrameBufferEncodingTypeZrleImplCopyWithImpl(
+      _$RemoteFrameBufferEncodingTypeZrleImpl _value,
+      $Res Function(_$RemoteFrameBufferEncodingTypeZrleImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of RemoteFrameBufferEncodingType
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$RemoteFrameBufferEncodingTypeZrleImpl
+    extends RemoteFrameBufferEncodingTypeZrle {
+  const _$RemoteFrameBufferEncodingTypeZrleImpl() : super._();
+
+  @override
+  String toString() {
+    return 'RemoteFrameBufferEncodingType.zrle()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$RemoteFrameBufferEncodingTypeZrleImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() copyRect,
+    required TResult Function() raw,
+    required TResult Function() zrle,
+    required TResult Function(ByteData bytes) unsupported,
+  }) {
+    return zrle();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? copyRect,
+    TResult? Function()? raw,
+    TResult? Function()? zrle,
+    TResult? Function(ByteData bytes)? unsupported,
+  }) {
+    return zrle?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? copyRect,
+    TResult Function()? raw,
+    TResult Function()? zrle,
+    TResult Function(ByteData bytes)? unsupported,
+    required TResult orElse(),
+  }) {
+    if (zrle != null) {
+      return zrle();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(RemoteFrameBufferEncodingTypeCopyRect value)
+        copyRect,
+    required TResult Function(RemoteFrameBufferEncodingTypeRaw value) raw,
+    required TResult Function(RemoteFrameBufferEncodingTypeZrle value) zrle,
+    required TResult Function(RemoteFrameBufferEncodingTypeUnsupported value)
+        unsupported,
+  }) {
+    return zrle(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(RemoteFrameBufferEncodingTypeCopyRect value)? copyRect,
+    TResult? Function(RemoteFrameBufferEncodingTypeRaw value)? raw,
+    TResult? Function(RemoteFrameBufferEncodingTypeZrle value)? zrle,
+    TResult? Function(RemoteFrameBufferEncodingTypeUnsupported value)?
+        unsupported,
+  }) {
+    return zrle?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(RemoteFrameBufferEncodingTypeCopyRect value)? copyRect,
+    TResult Function(RemoteFrameBufferEncodingTypeRaw value)? raw,
+    TResult Function(RemoteFrameBufferEncodingTypeZrle value)? zrle,
+    TResult Function(RemoteFrameBufferEncodingTypeUnsupported value)?
+        unsupported,
+    required TResult orElse(),
+  }) {
+    if (zrle != null) {
+      return zrle(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class RemoteFrameBufferEncodingTypeZrle
+    extends RemoteFrameBufferEncodingType {
+  const factory RemoteFrameBufferEncodingTypeZrle() =
+      _$RemoteFrameBufferEncodingTypeZrleImpl;
+  const RemoteFrameBufferEncodingTypeZrle._() : super._();
 }
 
 /// @nodoc
@@ -347,6 +503,8 @@ class __$$RemoteFrameBufferEncodingTypeUnsupportedImplCopyWithImpl<$Res>
       $Res Function(_$RemoteFrameBufferEncodingTypeUnsupportedImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of RemoteFrameBufferEncodingType
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -377,7 +535,7 @@ class _$RemoteFrameBufferEncodingTypeUnsupportedImpl
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$RemoteFrameBufferEncodingTypeUnsupportedImpl &&
@@ -387,7 +545,9 @@ class _$RemoteFrameBufferEncodingTypeUnsupportedImpl
   @override
   int get hashCode => Object.hash(runtimeType, bytes);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RemoteFrameBufferEncodingType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$RemoteFrameBufferEncodingTypeUnsupportedImplCopyWith<
@@ -401,6 +561,7 @@ class _$RemoteFrameBufferEncodingTypeUnsupportedImpl
   TResult when<TResult extends Object?>({
     required TResult Function() copyRect,
     required TResult Function() raw,
+    required TResult Function() zrle,
     required TResult Function(ByteData bytes) unsupported,
   }) {
     return unsupported(bytes);
@@ -411,6 +572,7 @@ class _$RemoteFrameBufferEncodingTypeUnsupportedImpl
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? copyRect,
     TResult? Function()? raw,
+    TResult? Function()? zrle,
     TResult? Function(ByteData bytes)? unsupported,
   }) {
     return unsupported?.call(bytes);
@@ -421,6 +583,7 @@ class _$RemoteFrameBufferEncodingTypeUnsupportedImpl
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? copyRect,
     TResult Function()? raw,
+    TResult Function()? zrle,
     TResult Function(ByteData bytes)? unsupported,
     required TResult orElse(),
   }) {
@@ -436,6 +599,7 @@ class _$RemoteFrameBufferEncodingTypeUnsupportedImpl
     required TResult Function(RemoteFrameBufferEncodingTypeCopyRect value)
         copyRect,
     required TResult Function(RemoteFrameBufferEncodingTypeRaw value) raw,
+    required TResult Function(RemoteFrameBufferEncodingTypeZrle value) zrle,
     required TResult Function(RemoteFrameBufferEncodingTypeUnsupported value)
         unsupported,
   }) {
@@ -447,6 +611,7 @@ class _$RemoteFrameBufferEncodingTypeUnsupportedImpl
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(RemoteFrameBufferEncodingTypeCopyRect value)? copyRect,
     TResult? Function(RemoteFrameBufferEncodingTypeRaw value)? raw,
+    TResult? Function(RemoteFrameBufferEncodingTypeZrle value)? zrle,
     TResult? Function(RemoteFrameBufferEncodingTypeUnsupported value)?
         unsupported,
   }) {
@@ -458,6 +623,7 @@ class _$RemoteFrameBufferEncodingTypeUnsupportedImpl
   TResult maybeMap<TResult extends Object?>({
     TResult Function(RemoteFrameBufferEncodingTypeCopyRect value)? copyRect,
     TResult Function(RemoteFrameBufferEncodingTypeRaw value)? raw,
+    TResult Function(RemoteFrameBufferEncodingTypeZrle value)? zrle,
     TResult Function(RemoteFrameBufferEncodingTypeUnsupported value)?
         unsupported,
     required TResult orElse(),
@@ -477,7 +643,10 @@ abstract class RemoteFrameBufferEncodingTypeUnsupported
   const RemoteFrameBufferEncodingTypeUnsupported._() : super._();
 
   ByteData get bytes;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of RemoteFrameBufferEncodingType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$RemoteFrameBufferEncodingTypeUnsupportedImplCopyWith<
           _$RemoteFrameBufferEncodingTypeUnsupportedImpl>
       get copyWith => throw _privateConstructorUsedError;

--- a/lib/src/protocol/frame_buffer_update_message.freezed.dart
+++ b/lib/src/protocol/frame_buffer_update_message.freezed.dart
@@ -12,14 +12,16 @@ part of 'frame_buffer_update_message.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$RemoteFrameBufferFrameBufferUpdateMessage {
   Iterable<RemoteFrameBufferFrameBufferUpdateMessageRectangle> get rectangles =>
       throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RemoteFrameBufferFrameBufferUpdateMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $RemoteFrameBufferFrameBufferUpdateMessageCopyWith<
           RemoteFrameBufferFrameBufferUpdateMessage>
       get copyWith => throw _privateConstructorUsedError;
@@ -50,6 +52,8 @@ class _$RemoteFrameBufferFrameBufferUpdateMessageCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of RemoteFrameBufferFrameBufferUpdateMessage
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -88,6 +92,8 @@ class __$$RemoteFrameBufferFrameBufferUpdateMessageImplCopyWithImpl<$Res>
       $Res Function(_$RemoteFrameBufferFrameBufferUpdateMessageImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of RemoteFrameBufferFrameBufferUpdateMessage
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -119,7 +125,7 @@ class _$RemoteFrameBufferFrameBufferUpdateMessageImpl
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$RemoteFrameBufferFrameBufferUpdateMessageImpl &&
@@ -131,7 +137,9 @@ class _$RemoteFrameBufferFrameBufferUpdateMessageImpl
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(rectangles));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RemoteFrameBufferFrameBufferUpdateMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$RemoteFrameBufferFrameBufferUpdateMessageImplCopyWith<
@@ -152,8 +160,11 @@ abstract class _RemoteFrameBufferFrameBufferUpdateMessage
 
   @override
   Iterable<RemoteFrameBufferFrameBufferUpdateMessageRectangle> get rectangles;
+
+  /// Create a copy of RemoteFrameBufferFrameBufferUpdateMessage
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$RemoteFrameBufferFrameBufferUpdateMessageImplCopyWith<
           _$RemoteFrameBufferFrameBufferUpdateMessageImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -169,7 +180,9 @@ mixin _$RemoteFrameBufferFrameBufferUpdateMessageRectangle {
   int get x => throw _privateConstructorUsedError;
   int get y => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RemoteFrameBufferFrameBufferUpdateMessageRectangle
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $RemoteFrameBufferFrameBufferUpdateMessageRectangleCopyWith<
           RemoteFrameBufferFrameBufferUpdateMessageRectangle>
       get copyWith => throw _privateConstructorUsedError;
@@ -209,6 +222,8 @@ class _$RemoteFrameBufferFrameBufferUpdateMessageRectangleCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of RemoteFrameBufferFrameBufferUpdateMessageRectangle
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -247,6 +262,8 @@ class _$RemoteFrameBufferFrameBufferUpdateMessageRectangleCopyWithImpl<$Res,
     ) as $Val);
   }
 
+  /// Create a copy of RemoteFrameBufferFrameBufferUpdateMessageRectangle
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $RemoteFrameBufferEncodingTypeCopyWith<$Res> get encodingType {
@@ -297,6 +314,8 @@ class __$$RemoteFrameBufferFrameBufferUpdateMessageRectangleImplCopyWithImpl<
           _then)
       : super(_value, _then);
 
+  /// Create a copy of RemoteFrameBufferFrameBufferUpdateMessageRectangle
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -367,7 +386,7 @@ class _$RemoteFrameBufferFrameBufferUpdateMessageRectangleImpl
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$RemoteFrameBufferFrameBufferUpdateMessageRectangleImpl &&
@@ -385,7 +404,9 @@ class _$RemoteFrameBufferFrameBufferUpdateMessageRectangleImpl
   int get hashCode =>
       Object.hash(runtimeType, encodingType, height, pixelData, width, x, y);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RemoteFrameBufferFrameBufferUpdateMessageRectangle
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$RemoteFrameBufferFrameBufferUpdateMessageRectangleImplCopyWith<
@@ -419,8 +440,11 @@ abstract class _RemoteFrameBufferFrameBufferUpdateMessageRectangle
   int get x;
   @override
   int get y;
+
+  /// Create a copy of RemoteFrameBufferFrameBufferUpdateMessageRectangle
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$RemoteFrameBufferFrameBufferUpdateMessageRectangleImplCopyWith<
           _$RemoteFrameBufferFrameBufferUpdateMessageRectangleImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -435,7 +459,9 @@ mixin _$RemoteFrameBufferFrameBufferUpdateMessageRectangleHeader {
   int get x => throw _privateConstructorUsedError;
   int get y => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RemoteFrameBufferFrameBufferUpdateMessageRectangleHeader
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $RemoteFrameBufferFrameBufferUpdateMessageRectangleHeaderCopyWith<
           RemoteFrameBufferFrameBufferUpdateMessageRectangleHeader>
       get copyWith => throw _privateConstructorUsedError;
@@ -477,6 +503,8 @@ class _$RemoteFrameBufferFrameBufferUpdateMessageRectangleHeaderCopyWithImpl<
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of RemoteFrameBufferFrameBufferUpdateMessageRectangleHeader
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -510,6 +538,8 @@ class _$RemoteFrameBufferFrameBufferUpdateMessageRectangleHeaderCopyWithImpl<
     ) as $Val);
   }
 
+  /// Create a copy of RemoteFrameBufferFrameBufferUpdateMessageRectangleHeader
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $RemoteFrameBufferEncodingTypeCopyWith<$Res> get encodingType {
@@ -561,6 +591,8 @@ class __$$RemoteFrameBufferFrameBufferUpdateMessageRectangleHeaderImplCopyWithIm
           _then)
       : super(_value, _then);
 
+  /// Create a copy of RemoteFrameBufferFrameBufferUpdateMessageRectangleHeader
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -624,7 +656,7 @@ class _$RemoteFrameBufferFrameBufferUpdateMessageRectangleHeaderImpl
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other
@@ -641,7 +673,9 @@ class _$RemoteFrameBufferFrameBufferUpdateMessageRectangleHeaderImpl
   int get hashCode =>
       Object.hash(runtimeType, encodingType, height, width, x, y);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RemoteFrameBufferFrameBufferUpdateMessageRectangleHeader
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$RemoteFrameBufferFrameBufferUpdateMessageRectangleHeaderImplCopyWith<
@@ -674,8 +708,11 @@ abstract class _RemoteFrameBufferFrameBufferUpdateMessageRectangleHeader
   int get x;
   @override
   int get y;
+
+  /// Create a copy of RemoteFrameBufferFrameBufferUpdateMessageRectangleHeader
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$RemoteFrameBufferFrameBufferUpdateMessageRectangleHeaderImplCopyWith<
           _$RemoteFrameBufferFrameBufferUpdateMessageRectangleHeaderImpl>
       get copyWith => throw _privateConstructorUsedError;

--- a/lib/src/protocol/server_init_message.freezed.dart
+++ b/lib/src/protocol/server_init_message.freezed.dart
@@ -12,7 +12,7 @@ part of 'server_init_message.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$RemoteFrameBufferServerInitMessage {
@@ -22,7 +22,9 @@ mixin _$RemoteFrameBufferServerInitMessage {
   RemoteFrameBufferPixelFormat get serverPixelFormat =>
       throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RemoteFrameBufferServerInitMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $RemoteFrameBufferServerInitMessageCopyWith<
           RemoteFrameBufferServerInitMessage>
       get copyWith => throw _privateConstructorUsedError;
@@ -56,6 +58,8 @@ class _$RemoteFrameBufferServerInitMessageCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of RemoteFrameBufferServerInitMessage
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -84,6 +88,8 @@ class _$RemoteFrameBufferServerInitMessageCopyWithImpl<$Res,
     ) as $Val);
   }
 
+  /// Create a copy of RemoteFrameBufferServerInitMessage
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $RemoteFrameBufferPixelFormatCopyWith<$Res> get serverPixelFormat {
@@ -123,6 +129,8 @@ class __$$RemoteFrameBufferServerInitMessageImplCopyWithImpl<$Res>
       $Res Function(_$RemoteFrameBufferServerInitMessageImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of RemoteFrameBufferServerInitMessage
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -178,7 +186,7 @@ class _$RemoteFrameBufferServerInitMessageImpl
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$RemoteFrameBufferServerInitMessageImpl &&
@@ -197,7 +205,9 @@ class _$RemoteFrameBufferServerInitMessageImpl
   int get hashCode => Object.hash(runtimeType, frameBufferHeightInPixels,
       frameBufferWidthInPixels, name, serverPixelFormat);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RemoteFrameBufferServerInitMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$RemoteFrameBufferServerInitMessageImplCopyWith<
@@ -224,8 +234,11 @@ abstract class _RemoteFrameBufferServerInitMessage
   String get name;
   @override
   RemoteFrameBufferPixelFormat get serverPixelFormat;
+
+  /// Create a copy of RemoteFrameBufferServerInitMessage
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$RemoteFrameBufferServerInitMessageImplCopyWith<
           _$RemoteFrameBufferServerInitMessageImpl>
       get copyWith => throw _privateConstructorUsedError;

--- a/lib/src/protocol/set_encodings_message.freezed.dart
+++ b/lib/src/protocol/set_encodings_message.freezed.dart
@@ -12,14 +12,16 @@ part of 'set_encodings_message.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$RemoteFrameBufferSetEncodingsMessage {
   Iterable<RemoteFrameBufferEncodingType> get encodingTypes =>
       throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RemoteFrameBufferSetEncodingsMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $RemoteFrameBufferSetEncodingsMessageCopyWith<
           RemoteFrameBufferSetEncodingsMessage>
       get copyWith => throw _privateConstructorUsedError;
@@ -47,6 +49,8 @@ class _$RemoteFrameBufferSetEncodingsMessageCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of RemoteFrameBufferSetEncodingsMessage
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -83,6 +87,8 @@ class __$$RemoteFrameBufferSetEncodingsMessageImplCopyWithImpl<$Res>
       $Res Function(_$RemoteFrameBufferSetEncodingsMessageImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of RemoteFrameBufferSetEncodingsMessage
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -114,7 +120,7 @@ class _$RemoteFrameBufferSetEncodingsMessageImpl
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$RemoteFrameBufferSetEncodingsMessageImpl &&
@@ -126,7 +132,9 @@ class _$RemoteFrameBufferSetEncodingsMessageImpl
   int get hashCode => Object.hash(
       runtimeType, const DeepCollectionEquality().hash(encodingTypes));
 
-  @JsonKey(ignore: true)
+  /// Create a copy of RemoteFrameBufferSetEncodingsMessage
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$RemoteFrameBufferSetEncodingsMessageImplCopyWith<
@@ -144,8 +152,11 @@ abstract class _RemoteFrameBufferSetEncodingsMessage
 
   @override
   Iterable<RemoteFrameBufferEncodingType> get encodingTypes;
+
+  /// Create a copy of RemoteFrameBufferSetEncodingsMessage
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$RemoteFrameBufferSetEncodingsMessageImplCopyWith<
           _$RemoteFrameBufferSetEncodingsMessageImpl>
       get copyWith => throw _privateConstructorUsedError;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,5 +20,4 @@ dependencies:
   dart_des: ^1.0.2
   fpdart: ^0.4.0
   freezed_annotation: ^2.4.1
-  json_annotation: ^4.8.1
   logging: ^1.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 description: Implementation of The Remote Framebuffer Protocol (RFC 6143, aka VNC protocol)
 name: dart_rfb
 repository: https://github.com/Goddchen/dart-rfb
-version: 0.8.0
+version: 0.9.0
 
 environment:
   sdk: ">=3.1.0 <4.0.0"
@@ -10,7 +10,7 @@ dev_dependencies:
   build_runner: ^2.3.3
   fake_async: ^1.3.1
   flutter_lints: ^2.0.1
-  freezed: ^2.3.2
+  freezed: ^2.5.2
   lints: ^2.0.0
   mockito: ^5.4.3
   test: ^1.16.0
@@ -19,5 +19,6 @@ dependencies:
   collection: ^1.16.0
   dart_des: ^1.0.2
   fpdart: ^0.4.0
-  freezed_annotation: ^2.2.0
+  freezed_annotation: ^2.4.1
+  json_annotation: ^4.8.1
   logging: ^1.1.0

--- a/test/client/rectangle_converter_test.dart
+++ b/test/client/rectangle_converter_test.dart
@@ -1,0 +1,87 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dart_rfb/src/client/rectangle_converter.dart';
+import 'package:dart_rfb/src/client/remote_frame_buffer_client_update.dart';
+import 'package:dart_rfb/src/encodings/zrle_decoder.dart';
+import 'package:dart_rfb/src/protocol/encoding_type.dart';
+import 'package:dart_rfb/src/protocol/frame_buffer_update_message.dart';
+import 'package:dart_rfb/src/protocol/pixel_format.dart';
+import 'package:logging/logging.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+void main() {
+  final RemoteFrameBufferRectangleConverter converter =
+      RemoteFrameBufferRectangleConverter(
+    logger: Logger('RectangleConverterTest'),
+  );
+
+  test('convert decodes ZRLE rectangle when decoder available', () {
+    final ByteData zrleData = _buildZrleData(
+      <int>[
+        0,
+        0xAA,
+        0xBB,
+        0xCC,
+      ],
+    );
+    final RemoteFrameBufferFrameBufferUpdateMessageRectangle rectangle =
+        RemoteFrameBufferFrameBufferUpdateMessageRectangle(
+      encodingType: const RemoteFrameBufferEncodingType.zrle(),
+      height: 1,
+      pixelData: zrleData,
+      width: 1,
+      x: 0,
+      y: 0,
+    );
+    final RemoteFrameBufferClientUpdateRectangle result = converter.convert(
+      rectangle: rectangle,
+      zrleDecoder:
+          ZrleDecoder(pixelFormat: RemoteFrameBufferPixelFormat.bgra8888),
+    );
+    expect(result.encodingType, equals(const RemoteFrameBufferEncodingType.raw()));
+    expect(
+      result.byteData.buffer.asUint8List(),
+      equals(
+        Uint8List.fromList(
+          <int>[0xAA, 0xBB, 0xCC, 0x00],
+        ),
+      ),
+    );
+  });
+
+  test('convert leaves rectangle untouched when decoder missing', () {
+    final RemoteFrameBufferFrameBufferUpdateMessageRectangle rectangle =
+        RemoteFrameBufferFrameBufferUpdateMessageRectangle(
+      encodingType: const RemoteFrameBufferEncodingType.zrle(),
+      height: 1,
+      pixelData: ByteData(4)..setUint32(0, 0),
+      width: 1,
+      x: 0,
+      y: 0,
+    );
+    final RemoteFrameBufferClientUpdateRectangle result = converter.convert(
+      rectangle: rectangle,
+      zrleDecoder: null,
+    );
+    expect(
+      result.encodingType,
+      equals(const RemoteFrameBufferEncodingType.zrle()),
+    );
+    expect(result.byteData.buffer.asUint8List(), equals(rectangle.pixelData.buffer.asUint8List()));
+  });
+}
+
+ByteData _buildZrleData(final List<int> decompressed) {
+  final Uint8List compressed =
+      Uint8List.fromList(ZLibEncoder().convert(decompressed));
+  final BytesBuilder builder = BytesBuilder()
+    ..add(
+      (ByteData(4)..setUint32(0, compressed.length)).buffer.asUint8List(),
+    )
+    ..add(compressed);
+  return ByteData.sublistView(builder.toBytes());
+}
+

--- a/test/client/rectangle_converter_test.dart
+++ b/test/client/rectangle_converter_test.dart
@@ -7,6 +7,7 @@ import 'package:dart_rfb/src/encodings/zrle_decoder.dart';
 import 'package:dart_rfb/src/protocol/encoding_type.dart';
 import 'package:dart_rfb/src/protocol/frame_buffer_update_message.dart';
 import 'package:dart_rfb/src/protocol/pixel_format.dart';
+import 'package:fpdart/fpdart.dart';
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
 
@@ -34,8 +35,9 @@ void main() {
     );
     final RemoteFrameBufferClientUpdateRectangle result = converter.convert(
       rectangle: rectangle,
-      zrleDecoder:
-          ZrleDecoder(pixelFormat: RemoteFrameBufferPixelFormat.bgra8888),
+      zrleDecoder: Option.of(
+        ZrleDecoder(pixelFormat: RemoteFrameBufferPixelFormat.bgra8888),
+      ),
     );
     expect(result.encodingType, equals(const RemoteFrameBufferEncodingType.raw()));
     expect(
@@ -60,7 +62,7 @@ void main() {
     );
     final RemoteFrameBufferClientUpdateRectangle result = converter.convert(
       rectangle: rectangle,
-      zrleDecoder: null,
+      zrleDecoder: const Option.none(),
     );
     expect(
       result.encodingType,

--- a/test/client/rectangle_converter_test.dart
+++ b/test/client/rectangle_converter_test.dart
@@ -7,15 +7,12 @@ import 'package:dart_rfb/src/encodings/zrle_decoder.dart';
 import 'package:dart_rfb/src/protocol/encoding_type.dart';
 import 'package:dart_rfb/src/protocol/frame_buffer_update_message.dart';
 import 'package:dart_rfb/src/protocol/pixel_format.dart';
-import 'package:logging/logging.dart';
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
 
 void main() {
   final RemoteFrameBufferRectangleConverter converter =
-      RemoteFrameBufferRectangleConverter(
-    logger: Logger('RectangleConverterTest'),
-  );
+      RemoteFrameBufferRectangleConverter();
 
   test('convert decodes ZRLE rectangle when decoder available', () {
     final ByteData zrleData = _buildZrleData(
@@ -83,5 +80,21 @@ ByteData _buildZrleData(final List<int> decompressed) {
     ..add(compressed);
   return ByteData.sublistView(builder.toBytes());
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 

--- a/test/client/rectangle_converter_test.dart
+++ b/test/client/rectangle_converter_test.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -84,4 +83,5 @@ ByteData _buildZrleData(final List<int> decompressed) {
     ..add(compressed);
   return ByteData.sublistView(builder.toBytes());
 }
+
 

--- a/test/client/rectangle_converter_test.dart
+++ b/test/client/rectangle_converter_test.dart
@@ -35,7 +35,7 @@ void main() {
     );
     final RemoteFrameBufferClientUpdateRectangle result = converter.convert(
       rectangle: rectangle,
-      zrleDecoder: Option.of(
+      zrleDecoder: Option<ZrleDecoder>.of(
         ZrleDecoder(pixelFormat: RemoteFrameBufferPixelFormat.bgra8888),
       ),
     );
@@ -62,7 +62,7 @@ void main() {
     );
     final RemoteFrameBufferClientUpdateRectangle result = converter.convert(
       rectangle: rectangle,
-      zrleDecoder: const Option.none(),
+      zrleDecoder: const Option<ZrleDecoder>.none(),
     );
     expect(
       result.encodingType,
@@ -82,21 +82,3 @@ ByteData _buildZrleData(final List<int> decompressed) {
     ..add(compressed);
   return ByteData.sublistView(builder.toBytes());
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/test/encodings/zrle_decoder_test.dart
+++ b/test/encodings/zrle_decoder_test.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -93,4 +92,3 @@ ByteData _buildZrleData(final List<int> decompressedBytes) {
     ..add(compressed);
   return ByteData.sublistView(builder.toBytes());
 }
-

--- a/test/encodings/zrle_decoder_test.dart
+++ b/test/encodings/zrle_decoder_test.dart
@@ -1,0 +1,96 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dart_rfb/src/encodings/zrle_decoder.dart';
+import 'package:dart_rfb/src/protocol/pixel_format.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+void main() {
+  final RemoteFrameBufferPixelFormat pixelFormat =
+      RemoteFrameBufferPixelFormat.bgra8888;
+  final ZrleDecoder decoder = ZrleDecoder(pixelFormat: pixelFormat);
+
+  test('decodes raw tile', () {
+    final ByteData zrleData = _buildZrleData(
+      <int>[
+        0, // raw tile
+        0x01,
+        0x02,
+        0x03,
+        0x10,
+        0x20,
+        0x30,
+      ],
+    );
+    final ByteData output = decoder.decode(
+      zrleData: zrleData,
+      width: 2,
+      height: 1,
+    );
+    expect(
+      output.buffer.asUint8List(),
+      equals(
+        Uint8List.fromList(
+          <int>[
+            0x01,
+            0x02,
+            0x03,
+            0x00,
+            0x10,
+            0x20,
+            0x30,
+            0x00,
+          ],
+        ),
+      ),
+    );
+  });
+
+  test('decodes plain RLE tile', () {
+    final ByteData zrleData = _buildZrleData(
+      <int>[
+        128, // plain RLE tile
+        0x0A,
+        0x0B,
+        0x0C, // color
+        0x01, // run length = 1 (default) + 1 => 2 pixels
+      ],
+    );
+    final ByteData output = decoder.decode(
+      zrleData: zrleData,
+      width: 2,
+      height: 1,
+    );
+    expect(
+      output.buffer.asUint8List(),
+      equals(
+        Uint8List.fromList(
+          <int>[
+            0x0A,
+            0x0B,
+            0x0C,
+            0x00,
+            0x0A,
+            0x0B,
+            0x0C,
+            0x00,
+          ],
+        ),
+      ),
+    );
+  });
+}
+
+ByteData _buildZrleData(final List<int> decompressedBytes) {
+  final Uint8List compressed =
+      Uint8List.fromList(ZLibCodec().encode(decompressedBytes));
+  final BytesBuilder builder = BytesBuilder()
+    ..add(
+      (ByteData(4)..setUint32(0, compressed.length)).buffer.asUint8List(),
+    )
+    ..add(compressed);
+  return ByteData.sublistView(builder.toBytes());
+}
+

--- a/test/protocol/encoding_type_test.dart
+++ b/test/protocol/encoding_type_test.dart
@@ -12,6 +12,12 @@ void main() {
       ),
       equals(const RemoteFrameBufferEncodingType.raw()),
     );
+    expect(
+      RemoteFrameBufferEncodingType.fromBytes(
+        bytes: ByteData(4)..setInt32(0, 16),
+      ),
+      equals(const RemoteFrameBufferEncodingType.zrle()),
+    );
     final RemoteFrameBufferEncodingType encodingType =
         RemoteFrameBufferEncodingType.fromBytes(
       bytes: ByteData(4)..setInt32(0, -1),
@@ -40,6 +46,15 @@ void main() {
           .asUint8List(),
       equals(
         (ByteData(4)..setInt32(0, 1)).buffer.asUint8List(),
+      ),
+    );
+    expect(
+      const RemoteFrameBufferEncodingType.zrle()
+          .toBytes()
+          .buffer
+          .asUint8List(),
+      equals(
+        (ByteData(4)..setInt32(0, 16)).buffer.asUint8List(),
       ),
     );
   });


### PR DESCRIPTION
## Summary

- add the `zrle` encoding type to the protocol definitions and announce it during capability negotiation
- rework rectangle parsing to extract ZRLE payloads (length + compressed data) and hand them to the converter
- introduce a pure-Dart `ZrleDecoder` that keeps a persistent zlib stream, decodes all tile types, and outputs raw pixel data
- wire the decoder into `RemoteFrameBufferClient` so ZRLE rectangles are converted eagerly before emitting framebuffer updates
- expand the rectangle converter tests to cover the new decoding path

## Testing

- flutter test test/client/rectangle_converter_test.dart
- manual connection against two live VNC servers using ZRLE (macOS client)